### PR TITLE
Fix test set evaluation GPU memory leak

### DIFF
--- a/src/full_model/evaluate_full_model/evaluate_language_model.py
+++ b/src/full_model/evaluate_full_model/evaluate_language_model.py
@@ -982,12 +982,19 @@ def update_gen_and_ref_sentences_for_regions(
             index_gen_ref_sentence += 1
 
 
-def get_generated_reports(generated_sentences_for_selected_regions, selected_regions, sentence_tokenizer, bertscore_threshold):
+def get_generated_reports(
+    generated_sentences_for_selected_regions,
+    selected_regions,
+    sentence_tokenizer,
+    bertscore_threshold,
+    bert_score,
+):
     """
     Args:
         generated_sentences_for_selected_regions (List[str]): of length "num_regions_selected_in_batch"
         selected_regions ([batch_size x 29]): boolean array that has exactly "num_regions_selected_in_batch" True values
         sentence_tokenizer: used in remove_duplicate_generated_sentences to separate the generated sentences
+        bert_score: instance of the evaluate bert score evaluation module
 
     Return:
         generated_reports (List[str]): list of length batch_size containing generated reports for every image in batch
@@ -1054,8 +1061,6 @@ def get_generated_reports(generated_sentences_for_selected_regions, selected_reg
         )
 
         return gen_report_single_image, similar_generated_sents_to_be_removed
-
-    bert_score = evaluate.load("bertscore")
 
     generated_reports = []
     removed_similar_generated_sentences = []

--- a/src/full_model/test_set_evaluation.py
+++ b/src/full_model/test_set_evaluation.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import spacy
 import torch
+import evaluate
 from torch.utils.data import DataLoader
 import torchmetrics
 from tqdm import tqdm
@@ -268,6 +269,7 @@ def evaluate_language_model_on_test_set(model, test_loader, test_2_loader, token
 
         # used in function get_generated_reports
         sentence_tokenizer = spacy.load("en_core_web_trf")
+        bert_score = evaluate.load("bertscore")
 
         with torch.no_grad():
             for num_batch, batch in tqdm(enumerate(test_loader)):
@@ -342,6 +344,14 @@ def evaluate_language_model_on_test_set(model, test_loader, test_2_loader, token
                     selected_regions,
                     sentence_tokenizer,
                     BERTSCORE_SIMILARITY_THRESHOLD
+                generated_reports, removed_similar_generated_sentences = (
+                    get_generated_reports(
+                        generated_sents_for_selected_regions,
+                        selected_regions,
+                        sentence_tokenizer,
+                        BERTSCORE_SIMILARITY_THRESHOLD,
+                        bert_score,
+                    )
                 )
 
                 gen_and_ref_sentences["generated_sentences"].extend(generated_sents_for_selected_regions)


### PR DESCRIPTION
Hi,

As I have been reproducing your results based on your codebase, I have noticed that the test-set evaluation script (`src/full_model/test_set_evaluation.py`) has a GPU memory leak. As it iterates through batches for the language model evaluation, GPU memory use keeps climbing from batch to batch. On my hardware, that led to out-of-memory errors at some later point in evaluation, even with a batch size of 1 whereas that was no problem at training.

I've tracked the source of the leak down, and it seems that re-initiating the `bertscore` evaluation module for each batch (as `get_generated_reports` is called inside the dataset iterator loop, and `evaluate.load("bertscore")` is called in the function) was what caused this behavior. 

By initiating the evaluation module once before the loop, and keeping it on GPU throughout the dataset iteration as done in my suggested modifications, the memory leak was resolved and larger batches could be used with stable GPU memory usage. 

Thank you for the excellent and very well documented work!